### PR TITLE
UTC

### DIFF
--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -284,7 +284,7 @@ export interface Database {
 }
 
 types.setTypeParser(types.builtins.TIMESTAMP, (datetimeString) => {
-  var temp = new Date(datetimeString)
+  const temp = new Date(datetimeString)
   return new Date(
     Date.UTC(
       temp.getFullYear(),

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -1,5 +1,4 @@
-import pg from 'pg'
-const { Pool } = pg
+import { Pool, types } from 'pg'
 
 import { Kysely, PostgresDialect, Generated, ColumnType } from 'kysely'
 import {
@@ -283,6 +282,21 @@ export interface Database {
   leagues: LeagueTable
   players: PlayerTable
 }
+
+types.setTypeParser(types.builtins.TIMESTAMP, (datetimeString) => {
+  var temp = new Date(datetimeString)
+  return new Date(
+    Date.UTC(
+      temp.getFullYear(),
+      temp.getMonth(),
+      temp.getDate(),
+      temp.getHours(),
+      temp.getMinutes(),
+      temp.getSeconds(),
+      temp.getMilliseconds()
+    )
+  )
+})
 
 export const db = new Kysely<Database>({
   dialect: new PostgresDialect({

--- a/packages/core/src/time.ts
+++ b/packages/core/src/time.ts
@@ -49,3 +49,12 @@ export function formatDateString(date: string, format = 'LL') {
 export function formatDate(date: Date, format = 'LL') {
   return dayjs(date).format(format)
 }
+
+export const utc = (s?: string): Date => {
+  if (s === undefined) return new Date(new Date().toISOString().slice(0, -1))
+  try {
+    return new Date(new Date(s).toISOString().slice(0, -1))
+  } catch (e) {
+    return new Date(s)
+  }
+}

--- a/packages/core/src/time.ts
+++ b/packages/core/src/time.ts
@@ -1,19 +1,19 @@
-import dayjs from "dayjs"
-import localizedFormat from "dayjs/plugin/localizedFormat"
-import advancedFormat from "dayjs/plugin/advancedFormat"
+import dayjs from 'dayjs'
+import localizedFormat from 'dayjs/plugin/localizedFormat'
+import advancedFormat from 'dayjs/plugin/advancedFormat'
 dayjs.extend(advancedFormat)
 dayjs.extend(localizedFormat)
 
 const units: { unit: Intl.RelativeTimeFormatUnit; ms: number }[] = [
-  { unit: "year", ms: 31536000000 },
-  { unit: "month", ms: 2628000000 },
-  { unit: "day", ms: 86400000 },
-  { unit: "hour", ms: 3600000 },
-  { unit: "minute", ms: 60000 },
-  { unit: "second", ms: 1000 },
+  { unit: 'year', ms: 31536000000 },
+  { unit: 'month', ms: 2628000000 },
+  { unit: 'day', ms: 86400000 },
+  { unit: 'hour', ms: 3600000 },
+  { unit: 'minute', ms: 60000 },
+  { unit: 'second', ms: 1000 },
 ]
 
-const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" })
+const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' })
 
 /**
  * Get language-sensitive relative time message from Dates.
@@ -24,7 +24,7 @@ export function relativeTimeFromDates(
   relative: Date | null,
   pivot: Date = new Date()
 ): string {
-  if (!relative) return ""
+  if (!relative) return ''
   const elapsed = relative.getTime() - pivot.getTime()
   return relativeTimeFromElapsed(elapsed)
 }
@@ -35,17 +35,17 @@ export function relativeTimeFromDates(
  */
 export function relativeTimeFromElapsed(elapsed: number): string {
   for (const { unit, ms } of units) {
-    if (Math.abs(elapsed) >= ms || unit === "second") {
+    if (Math.abs(elapsed) >= ms || unit === 'second') {
       return rtf.format(Math.round(elapsed / ms), unit)
     }
   }
-  return ""
+  return ''
 }
 
-export function formatDateString(date: string, format = "LL") {
+export function formatDateString(date: string, format = 'LL') {
   return formatDate(new Date(date), format)
 }
 
-export function formatDate(date: Date, format = "LL") {
+export function formatDate(date: Date, format = 'LL') {
   return dayjs(date).format(format)
 }

--- a/packages/web/src/components/ask-index.astro
+++ b/packages/web/src/components/ask-index.astro
@@ -4,7 +4,7 @@ import Header from '@components/header.astro'
 import Container from '@components/container.astro'
 import { ASK_LIMIT, type FinanceAsk, type Ask } from '@statmuse/core/asks'
 import { createAskPath } from '@lib/path'
-import { formatDate } from '@statmuse/core/time'
+import { formatDate, utc } from '@statmuse/core/time'
 import type { Metadata } from '@lib/meta'
 
 interface Props {
@@ -16,7 +16,7 @@ interface Props {
 const { domain, fetchAsks, meta } = Astro.props
 
 const dateFromString = (x: string) => {
-  const date = new Date(x)
+  const date = utc(x)
   if (date.toString() !== 'Invalid Date') {
     return date
   }
@@ -99,7 +99,7 @@ let asks = await fetchAsks(searchParams)
 
 const overflow = asks.length > ASK_LIMIT
 
-if (searchParams.p || (searchParams.page && searchParams.page === 'last')) {
+if (overflow && (searchParams.p || searchParams.page === 'last')) {
   asks = asks.slice(1)
 } else {
   asks = asks.slice(0, ASK_LIMIT)


### PR DESCRIPTION
Datetime columns within our postgres db are of type `timestamp without time zone` (implicitly stored in UTC) so makes sense to parse as utc date objects. 